### PR TITLE
Common .gitignore suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /vendor
+/vendor/
+
+/.idea
+/.idea/
+
+composer.phar


### PR DESCRIPTION
`/vendor` and `/vendor/` are not duplicates. It allows to use soft linked directories