### PR TITLE
Implementation of Line Feed in "alt text"

### DIFF
--- a/src/Layout/Serial/Component/ReaderTitle/ReaderTitle.js
+++ b/src/Layout/Serial/Component/ReaderTitle/ReaderTitle.js
@@ -1,0 +1,13 @@
+// Форматирование переносов строк в title изображений и ссылок читалки
+const formatReaderTitles = () => {
+    document.querySelectorAll('.reader-issue img.issue, .reader-issue a.reader-issue-next').forEach(element => {
+        const title = element.getAttribute('title');
+        if (title) {
+            const newTitle = title.replace(/\\r/g, '&#13;')
+                                .replace(/\\n/g, '&#10;');
+            const temp = document.createElement('div');
+            temp.innerHTML = newTitle;
+            element.setAttribute('title', temp.textContent);
+        }
+    });
+};

--- a/src/Layout/Serial/Component/ReaderTitle/ReaderTitle.js
+++ b/src/Layout/Serial/Component/ReaderTitle/ReaderTitle.js
@@ -1,6 +1,6 @@
 // Форматирование переносов строк в title изображений и ссылок читалки
 const formatReaderTitles = () => {
-    document.querySelectorAll('.reader-issue img.issue, .reader-issue a.reader-issue-next').forEach(element => {
+    document.querySelectorAll('.reader-issue img.issue, .reader-issue a.reader-issue-next, .reader-issue a.reader-issue-previous').forEach(element => {
         const title = element.getAttribute('title');
         if (title) {
             const newTitle = title.replace(/\\r/g, '&#13;')

--- a/src/Layout/Serial/SerialLayout.js
+++ b/src/Layout/Serial/SerialLayout.js
@@ -75,6 +75,7 @@ const initReaderPage = () => {
 	removeTitleHashFromUrl();
 	makeHeaderDisapearOnScroll();
     preventFormDoubleSubmission();
+	formatReaderTitles();
 };
 
 // Инициализация страницы содержания


### PR DESCRIPTION
Собственно, просто замена управляющих символов \n и \r на числовые сущности перевода строки и возврата каретки. По крайней мере, локально оно у меня работало.
Результат:
![image](https://github.com/user-attachments/assets/9e2c8cf0-914e-4d39-aa60-beac3023b4cb)
При "Альтернативном тексте" - `"И, смотря во мрак глубокий, долго ждал я, одинокий,\rПолный грез, что ведать смертным не давалось до того!\n--Эдгар Аллан По\r\nПеревод В. Брюсова"`
![image](https://github.com/user-attachments/assets/b6d61475-450b-4fdf-bc68-cc28c0aeb9b8)


На ссылке на предыдущую страницу, кстати, "Альт. текст" не отображается, но я всё равно проверку и туда поставила. На всякий, вдруг это баг, а не фича.